### PR TITLE
Fix: Improve rebalance page with manual stock entry and API protection

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -35,3 +35,7 @@ class RebalanceResponse(BaseModel):
 
 class TickerList(BaseModel):
     tickers: List[str]
+
+class RebalanceRequest(BaseModel):
+    universe: str = "test"
+    tickers: Optional[List[str]] = None

--- a/src/components/Dashboard8x8.js
+++ b/src/components/Dashboard8x8.js
@@ -67,17 +67,22 @@ const Dashboard8x8 = () => {
     }
   };
 
-  const handleRebalance = async (universe = 'test') => {
+  const handleRebalance = async (params) => {
     setLoading(true);
     setError(null);
     
     try {
+      // Handle different parameter formats
+      const requestBody = typeof params === 'string' 
+        ? { universe: params }
+        : params;
+      
       const response = await fetch('http://localhost:8000/api/rebalance-8x8', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ universe })
+        body: JSON.stringify(requestBody)
       });
       
       if (!response.ok) {

--- a/src/components/Rebalance8x8Panel.css
+++ b/src/components/Rebalance8x8Panel.css
@@ -89,6 +89,52 @@
   color: #888;
 }
 
+.manual-input-section {
+  margin-top: 1.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.manual-input-section label {
+  display: block;
+  color: #aaa;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.manual-tickers-input {
+  width: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 1rem;
+  color: #e0e0e0;
+  font-family: 'Monaco', 'Courier New', monospace;
+  font-size: 1rem;
+  resize: vertical;
+  margin-bottom: 0.5rem;
+  transition: all 0.3s;
+}
+
+.manual-tickers-input:focus {
+  outline: none;
+  border-color: #00ff88;
+  background: rgba(0, 255, 136, 0.05);
+}
+
+.manual-tickers-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.input-hint {
+  font-size: 0.85rem;
+  color: #666;
+  margin-bottom: 1rem;
+}
+
 .rebalance-button {
   width: 100%;
   background: linear-gradient(45deg, #00ff88, #00bbff);
@@ -308,6 +354,27 @@
 }
 
 .schedule-info strong {
+  color: #e0e0e0;
+}
+
+.universe-info {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.universe-info h4 {
+  color: #00bbff;
+  margin: 0 0 1rem 0;
+}
+
+.universe-info ul {
+  color: #aaa;
+  line-height: 1.8;
+  padding-left: 1.5rem;
+}
+
+.universe-info strong {
   color: #e0e0e0;
 }
 

--- a/test-manual-rebalance.js
+++ b/test-manual-rebalance.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+async function testManualRebalance() {
+  console.log('Testing Manual Rebalance Feature...\n');
+
+  // Test 1: Manual ticker entry with small list
+  console.log('1. Testing manual ticker entry with 5 stocks...');
+  const manualResponse = await fetch('http://localhost:8000/api/rebalance-8x8', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      universe: 'manual',
+      tickers: ['AAPL', 'MSFT', 'GOOGL', 'NVDA', 'V']
+    })
+  });
+  
+  const manualResult = await manualResponse.json();
+  console.log('Manual Rebalance Results:');
+  console.log(`- Total Scored: ${manualResult.total_scored}`);
+  console.log(`- Qualified: ${manualResult.qualified_count}`);
+  console.log(`- Eliminated: ${manualResult.eliminated_count}`);
+  if (manualResult.portfolio && manualResult.portfolio.length > 0) {
+    console.log('- Portfolio:');
+    manualResult.portfolio.forEach(stock => {
+      console.log(`  ${stock.ticker}: ${stock.total_score}/64 (${(stock.weight * 100).toFixed(1)}%)`);
+    });
+  }
+  console.log();
+
+  // Test 2: Check cached stocks
+  console.log('2. Checking cached stocks...');
+  const cachedResponse = await fetch('http://localhost:8000/api/cached-stocks');
+  const cachedResult = await cachedResponse.json();
+  console.log(`Cached stocks: ${cachedResult.count} stocks found`);
+  if (cachedResult.cached_stocks && cachedResult.cached_stocks.length > 0) {
+    console.log('First 5 cached stocks:');
+    cachedResult.cached_stocks.slice(0, 5).forEach(stock => {
+      console.log(`  ${stock.ticker}: Score ${stock.total_score}`);
+    });
+  }
+  console.log();
+
+  // Test 3: Rebalance with cached stocks
+  if (cachedResult.count > 0) {
+    console.log('3. Testing rebalance with cached stocks...');
+    const cachedRebalanceResponse = await fetch('http://localhost:8000/api/rebalance-8x8', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ universe: 'cached' })
+    });
+    
+    const cachedRebalanceResult = await cachedRebalanceResponse.json();
+    console.log('Cached Rebalance Results:');
+    console.log(`- Total Scored: ${cachedRebalanceResult.total_scored}`);
+    console.log(`- Qualified: ${cachedRebalanceResult.qualified_count}`);
+    console.log(`- Eliminated: ${cachedRebalanceResult.eliminated_count}`);
+  }
+
+  console.log('\n✅ All tests completed!');
+}
+
+testManualRebalance().catch(console.error);


### PR DESCRIPTION
## Summary
This PR addresses critical issues with the rebalance page, specifically API rate limit concerns and lack of flexibility in stock selection.

## Problems Solved
- **API Rate Limits**: S&P 500 testing would make 500+ API calls, potentially breaking rate limits
- **No Manual Entry**: Users couldn't test specific stocks of interest
- **No Data Reuse**: Previously analyzed stocks weren't being leveraged

## Changes Made

### Frontend (React)
- ✨ Added **Manual Entry** option with textarea for custom ticker lists (up to 20 stocks)
- 🔄 Replaced dangerous S&P 500 option with **Cached Stocks** option
- 🎨 Improved UI with better universe selection and visual feedback
- 📝 Added documentation explaining each universe option

### Backend (FastAPI)
- 🔌 New `/api/cached-stocks` endpoint to fetch previously analyzed stocks
- 🛡️ Limited manual entries to 20 stocks to protect API limits
- 🔒 Limited S&P 500 to 50 stocks max (if ever re-enabled)
- 📦 Support for manual ticker lists in rebalance requests

## Testing
- Created `test-manual-rebalance.js` to verify manual entry functionality
- Tested with small ticker lists (3-5 stocks)
- Verified cached stocks retrieval

## Screenshots
The rebalance page now offers three universe options:
1. **Test Universe** (~70 pre-selected stocks)
2. **Manual Entry** (custom ticker list, max 20)
3. **Cached Stocks** (reuse previously analyzed data)

## Impact
- Users can now safely test specific stocks without API concerns
- Previously analyzed data is reused, reducing API calls
- More flexible and user-friendly rebalancing experience

🤖 Generated with [Claude Code](https://claude.ai/code)